### PR TITLE
add sparse inputformat to data_io module with unittest

### DIFF
--- a/federatedml/util/test/data_io_test.py
+++ b/federatedml/util/test/data_io_test.py
@@ -15,25 +15,27 @@
 #
 
 import numpy as np
-import unittest
 import time
+import random
+import unittest
 
 from federatedml.util.data_io import DenseFeatureReader
+from federatedml.util.data_io import SparseFeatureReader
 from federatedml.param.param import DataIOParam
 from arch.api import eggroll
 from federatedml.util import consts
 
 
-class TestDataIO(unittest.TestCase):
+class TestDenseFeatureReader(unittest.TestCase):
     def setUp(self):
         eggroll.init("test_dataio" + str(int(time.time())))
-        self.table = "dataio_table_test"
+        self.table = "dataio_dense_table_test"
         self.namespace = "dataio_test"
         table = eggroll.parallelize([("a", "1,2,-1,0,0,5"), ("b", "4,5,6,0,1,2")], include_key=True)
         table.save_as(self.table, self.namespace)
 
-        self.table2 = "dataio_table_test2"
-        self.namespace2 = "dataio_test2"
+        self.table2 = "dataio_dense_table_test2"
+        self.namespace2 = "dataio_test"
         table2 = eggroll.parallelize([("a", '-1,,NA,NULL,null,2')], include_key=True)
         table2.save_as(self.table2, self.namespace2)
 
@@ -93,5 +95,123 @@ class TestDataIO(unittest.TestCase):
         self.assertTrue(features.shape[0] == 5)
 
 
+class TestSparseFeatureReader(unittest.TestCase):
+    def setUp(self):
+        eggroll.init("test_dataio" + str(int(time.time())))
+        self.table = "dataio_sparse_table_test"
+        self.abnormal_table = "dataio_sparse_abnormal_table_test"
+        self.namespace = "dataio_test"
+        self.data = []
+        self.abnormal_data = []
+        self.max_feature = -1
+        self.abnormal_max_feature = -1
+        for i in range(100):
+            row = []
+            abnormal_row = []
+            label = i % 2
+            row.append(str(label))
+            abnormal_row.append(str(label))
+            dict = {}
+            
+            for j in range(20):
+                x = random.randint(0, 1000)
+                val = random.random()
+                if x in dict:
+                    continue
+                self.max_feature = max(self.max_feature, x)
+                dict[x] = True
+                row.append(":".join(map(str, [x, val])))
+             
+                if i % 2 == 0:
+                    if x % 2 == 0:
+                        abnormal_row.append(":".join(map(str, [x, 'NA'])))
+                    else:
+                        abnormal_row.append(":".join(map(str, [x, val])))
+                    
+                    self.abnormal_max_feature = max(self.abnormal_max_feature, x)
+
+            self.data.append(" ".join(row))
+            self.abnormal_data.append(" ".join(abnormal_row))
+
+        table = eggroll.parallelize(self.data, include_key=False)
+        table.save_as(self.table, self.namespace)
+
+        abnormal_table = eggroll.parallelize(self.abnormal_data, 
+                                             include_key=False)
+        abnormal_table.save_as(self.abnormal_table, self.namespace)
+    
+    def test_sparse_output_format(self):
+        dataio_param = DataIOParam()
+        dataio_param.input_format = "sparse"
+        dataio_param.delimitor = ' '
+        dataio_param.default_value = 2**30
+        dataio_param.output_format = "sparse"
+        reader = SparseFeatureReader(dataio_param)
+        insts = list(reader.read_data(self.table, self.namespace).collect()) 
+        for i in range(100):
+            self.assertTrue(insts[i][1].features.get_shape() == self.max_feature + 1)
+            self.assertTrue(insts[i][1].label == i % 2)
+            original_feat = {}
+            row = self.data[i].split(" ")
+            for j in range(1, len(row)):
+                fid, val = row[j].split(":", -1)
+                original_feat[int(fid)] = float(val)
+ 
+            self.assertTrue(original_feat == insts[i][1].features.sparse_vec)
+
+    def test_dense_output_format(self):
+        dataio_param = DataIOParam()
+        dataio_param.input_format = "sparse"
+        dataio_param.delimitor = ' '
+        dataio_param.default_value = 2**30
+        dataio_param.output_format = "dense"
+        reader = SparseFeatureReader(dataio_param)
+        insts = list(reader.read_data(self.table, self.namespace).collect()) 
+        for i in range(100):
+            features = insts[i][1].features
+            self.assertTrue(type(features).__name__ == "ndarray")
+            self.assertTrue(features.shape[0] == self.max_feature + 1)
+            self.assertTrue(insts[i][1].label == i % 2)
+            
+            row = self.data[i].split(" ")
+            ori_feat = [2**30 for i in range(self.max_feature + 1)]
+            for j in range(1, len(row)):
+                fid, val = row[j].split(":", -1)
+                ori_feat[int(fid)] = float(val)
+            
+            ori_feat = np.asarray(ori_feat, dtype=dataio_param.data_type)
+    
+            self.assertTrue(np.abs(ori_feat - features).any() < consts.FLOAT_ZERO)
+
+    def test_missing_value_fill(self):
+        dataio_param = DataIOParam()
+        dataio_param.input_format = "sparse"
+        dataio_param.delimitor = ' '
+        dataio_param.default_value = 2**30
+        dataio_param.missing_fill = True
+        dataio_param.output_format = "sparse"
+        reader = SparseFeatureReader(dataio_param)
+        insts = list(reader.read_data(self.abnormal_table, self.namespace).collect()) 
+       
+        for i in range(100):
+            features = insts[i][1].features
+            self.assertTrue(features.get_shape() == self.abnormal_max_feature + 1)
+            self.assertTrue(insts[i][1].label == i % 2)
+
+            if i % 2 == 0:
+                row = self.abnormal_data[i].split(" ")
+                self.assertTrue(len(features.sparse_vec) == len(row) - 1)
+                for j in range(1, len(row)):
+                    fid, val = row[j].split(":", -1)
+                    fid = int(fid)
+                    self.assertTrue(fid in features.sparse_vec)
+                    trans_feat = features.get_data(fid)
+                    if fid % 2 == 0:
+                        self.assertTrue(np.abs(2**30 - trans_feat) < consts.FLOAT_ZERO)
+                    else:
+                        self.assertTrue(np.abs(float(val) - trans_feat) < consts.FLOAT_ZERO)
+            else:
+                self.assertTrue(len(features.sparse_vec) == 0)
+            
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
1. Adding svmlight sparse data input format in data_io.py
2. Adding uniitest for data_io, test file is data_io_test.py