### PR TITLE
Feature 0.2 one second latency

### DIFF
--- a/arch/networking/proxy/src/main/java/com/webank/ai/fate/networking/proxy/infra/impl/PacketQueuePipe.java
+++ b/arch/networking/proxy/src/main/java/com/webank/ai/fate/networking/proxy/infra/impl/PacketQueuePipe.java
@@ -63,6 +63,7 @@ public class PacketQueuePipe extends BasePipe {
 
     @Override
     public Proxy.Packet read(long timeout, TimeUnit unit) {
+        if (isDrained()) return result;
         Proxy.Packet result = null;
         try {
             result = queue.poll(timeout, unit);

--- a/arch/networking/proxy/src/main/java/com/webank/ai/fate/networking/proxy/infra/impl/PacketQueuePipe.java
+++ b/arch/networking/proxy/src/main/java/com/webank/ai/fate/networking/proxy/infra/impl/PacketQueuePipe.java
@@ -63,8 +63,8 @@ public class PacketQueuePipe extends BasePipe {
 
     @Override
     public Proxy.Packet read(long timeout, TimeUnit unit) {
-        if (isDrained()) return result;
         Proxy.Packet result = null;
+        if (isDrained()) return result;
         try {
             result = queue.poll(timeout, unit);
         } catch (InterruptedException e) {


### PR DESCRIPTION
Fixes  ISSUE#55

Changes:

1.add a line of code "if (isDrained()) return result;" between line 66 and line 67 of PacketQueuePipe.java(in arch/networking/proxy/src/main/java/com/webank/ai/fate/networking/proxy/infra/impl/)


