### PR TITLE
fix federation crash bug

### DIFF
--- a/arch/driver/federation/src/main/java/com/webank/ai/fate/driver/federation/transfer/communication/TransferJobScheduler.java
+++ b/arch/driver/federation/src/main/java/com/webank/ai/fate/driver/federation/transfer/communication/TransferJobScheduler.java
@@ -79,10 +79,11 @@ public class TransferJobScheduler implements Runnable {
 
     @Override
     public void run() {
-        try {
+
             boolean latchWaitResult = false;
             int waitCount = 0;
             while (System.currentTimeMillis() > 0) {
+                try {
                 while (!latchWaitResult && ++waitCount < 15 && jobQueue.isEmpty()) {
                     latchWaitResult = jobQueueReadyLatch.await(1, TimeUnit.SECONDS);
                 }
@@ -153,12 +154,14 @@ public class TransferJobScheduler implements Runnable {
                             transferMetaId, type.name());
                 }
 
+            } catch (Throwable e) {
+                LOGGER.error(errorUtils.getStackTrace(e));
+            }
+
 
             }
 
-        } catch (Exception e) {
-            LOGGER.error(errorUtils.getStackTrace(e));
-        }
+
     }
 
     @Async

--- a/arch/driver/federation/src/main/java/com/webank/ai/fate/driver/federation/transfer/communication/processor/SendProcessor.java
+++ b/arch/driver/federation/src/main/java/com/webank/ai/fate/driver/federation/transfer/communication/processor/SendProcessor.java
@@ -134,15 +134,16 @@ public class SendProcessor extends BaseTransferProcessor {
             TransferBrokerConsumer consumer = transferServiceFactory.createTransferBrokerConsumer();
             broker.addSubscriber(consumer);
 
+            ListenableFuture<?> consumerListenableFuture = ioConsumerPool.submitListenable(consumer);
+            consumerListenableFuture.addCallback(
+                    federationCallbackFactory.createDefaultConsumerListenableCallback(errorContainer, finishLatch, null, -1));
+
             // todo: add result tracking and retry mechanism
             ListenableFuture<BasicMeta.ReturnStatus> producerResult = ioProducerPool.submitListenable(producer);
             producerResult.addCallback(
                     federationCallbackFactory.createDtableSendProducerListenableCallback(results, broker, errorContainer, null, -1));
 
-            ListenableFuture<?> consumerListenableFuture = ioConsumerPool.submitListenable(consumer);
-            consumerListenableFuture.addCallback(
-                    federationCallbackFactory.createDefaultConsumerListenableCallback(errorContainer, finishLatch, null, -1));
-        }
+            }
 
         return finishLatch;
     }
@@ -162,13 +163,15 @@ public class SendProcessor extends BaseTransferProcessor {
         final List<BasicMeta.ReturnStatus> results = Collections.synchronizedList(Lists.newArrayList());
         CountDownLatch finishLatch = new CountDownLatch(1);
 
+        ListenableFuture<?> consumerListenableFuture = ioConsumerPool.submitListenable(consumer);
+        consumerListenableFuture.addCallback(
+                federationCallbackFactory.createDefaultConsumerListenableCallback(errorContainer, finishLatch, null, -1));
+
+
         ListenableFuture<BasicMeta.ReturnStatus> producerListenableFuture = ioProducerPool.submitListenable(producer);
         producerListenableFuture.addCallback(
                 federationCallbackFactory.createDtableSendProducerListenableCallback(results, broker, errorContainer, null, -1));
 
-        ListenableFuture<?> consumerListenableFuture = ioConsumerPool.submitListenable(consumer);
-        consumerListenableFuture.addCallback(
-                federationCallbackFactory.createDefaultConsumerListenableCallback(errorContainer, finishLatch, null, -1));
 
         return finishLatch;
     }


### PR DESCRIPTION
Fixes  ISSUE#xxx

Changes:

1.  com.webank.ai.fate.driver.federation.transfer.communication.TransferJobScheduler  
     fix:  if cannot get a thread from  threadpool,the poll thread will exit



