### PR TITLE
fix federation crash bug

### DIFF
--- a/arch/driver/federation/src/main/java/com/webank/ai/fate/driver/federation/transfer/communication/TransferJobScheduler.java
+++ b/arch/driver/federation/src/main/java/com/webank/ai/fate/driver/federation/transfer/communication/TransferJobScheduler.java
@@ -79,10 +79,11 @@ public class TransferJobScheduler implements Runnable {
 
     @Override
     public void run() {
-        try {
+
             boolean latchWaitResult = false;
             int waitCount = 0;
             while (System.currentTimeMillis() > 0) {
+                try {
                 while (!latchWaitResult && ++waitCount < 15 && jobQueue.isEmpty()) {
                     latchWaitResult = jobQueueReadyLatch.await(1, TimeUnit.SECONDS);
                 }
@@ -153,12 +154,14 @@ public class TransferJobScheduler implements Runnable {
                             transferMetaId, type.name());
                 }
 
+            } catch (Throwable e) {
+                LOGGER.error(errorUtils.getStackTrace(e));
+            }
+
 
             }
 
-        } catch (Exception e) {
-            LOGGER.error(errorUtils.getStackTrace(e));
-        }
+
     }
 
     @Async

--- a/arch/driver/federation/src/main/java/com/webank/ai/fate/driver/federation/transfer/communication/processor/SendProcessor.java
+++ b/arch/driver/federation/src/main/java/com/webank/ai/fate/driver/federation/transfer/communication/processor/SendProcessor.java
@@ -134,16 +134,14 @@ public class SendProcessor extends BaseTransferProcessor {
             TransferBrokerConsumer consumer = transferServiceFactory.createTransferBrokerConsumer();
             broker.addSubscriber(consumer);
 
+            // todo: add result tracking and retry mechanism
+            ListenableFuture<BasicMeta.ReturnStatus> producerResult = ioProducerPool.submitListenable(producer);
+            producerResult.addCallback(
+                    federationCallbackFactory.createDtableSendProducerListenableCallback(results, broker, errorContainer, null, -1));
+
             ListenableFuture<?> consumerListenableFuture = ioConsumerPool.submitListenable(consumer);
-            if (consumerListenableFuture != null) {
             consumerListenableFuture.addCallback(
                     federationCallbackFactory.createDefaultConsumerListenableCallback(errorContainer, finishLatch, null, -1));
-                // todo: add result tracking and retry mechanism
-                ListenableFuture<BasicMeta.ReturnStatus> producerResult = ioProducerPool.submitListenable(producer);
-                producerResult.addCallback(
-                        federationCallbackFactory.createDtableSendProducerListenableCallback(results, broker, errorContainer, null, -1));
-
-            }
         }
 
         return finishLatch;
@@ -164,15 +162,14 @@ public class SendProcessor extends BaseTransferProcessor {
         final List<BasicMeta.ReturnStatus> results = Collections.synchronizedList(Lists.newArrayList());
         CountDownLatch finishLatch = new CountDownLatch(1);
 
+        ListenableFuture<BasicMeta.ReturnStatus> producerListenableFuture = ioProducerPool.submitListenable(producer);
+        producerListenableFuture.addCallback(
+                federationCallbackFactory.createDtableSendProducerListenableCallback(results, broker, errorContainer, null, -1));
+
         ListenableFuture<?> consumerListenableFuture = ioConsumerPool.submitListenable(consumer);
-        if(consumerListenableFuture!=null) {
         consumerListenableFuture.addCallback(
                 federationCallbackFactory.createDefaultConsumerListenableCallback(errorContainer, finishLatch, null, -1));
-            ListenableFuture<BasicMeta.ReturnStatus> producerListenableFuture = ioProducerPool.submitListenable(producer);
-            producerListenableFuture.addCallback(
-                    federationCallbackFactory.createDtableSendProducerListenableCallback(results, broker, errorContainer, null, -1));
 
-        }
         return finishLatch;
     }
 

--- a/arch/driver/federation/src/main/java/com/webank/ai/fate/driver/federation/transfer/communication/processor/SendProcessor.java
+++ b/arch/driver/federation/src/main/java/com/webank/ai/fate/driver/federation/transfer/communication/processor/SendProcessor.java
@@ -134,15 +134,16 @@ public class SendProcessor extends BaseTransferProcessor {
             TransferBrokerConsumer consumer = transferServiceFactory.createTransferBrokerConsumer();
             broker.addSubscriber(consumer);
 
+            ListenableFuture<?> consumerListenableFuture = ioConsumerPool.submitListenable(consumer);
+            consumerListenableFuture.addCallback(
+                    federationCallbackFactory.createDefaultConsumerListenableCallback(errorContainer, finishLatch, null, -1));
+
             // todo: add result tracking and retry mechanism
             ListenableFuture<BasicMeta.ReturnStatus> producerResult = ioProducerPool.submitListenable(producer);
             producerResult.addCallback(
                     federationCallbackFactory.createDtableSendProducerListenableCallback(results, broker, errorContainer, null, -1));
 
-            ListenableFuture<?> consumerListenableFuture = ioConsumerPool.submitListenable(consumer);
-            consumerListenableFuture.addCallback(
-                    federationCallbackFactory.createDefaultConsumerListenableCallback(errorContainer, finishLatch, null, -1));
-        }
+            }
 
         return finishLatch;
     }
@@ -162,13 +163,15 @@ public class SendProcessor extends BaseTransferProcessor {
         final List<BasicMeta.ReturnStatus> results = Collections.synchronizedList(Lists.newArrayList());
         CountDownLatch finishLatch = new CountDownLatch(1);
 
+        ListenableFuture<?> consumerListenableFuture = ioConsumerPool.submitListenable(consumer);
+        consumerListenableFuture.addCallback(
+                federationCallbackFactory.createDefaultConsumerListenableCallback(errorContainer, finishLatch, null, -1));
+
+
         ListenableFuture<BasicMeta.ReturnStatus> producerListenableFuture = ioProducerPool.submitListenable(producer);
         producerListenableFuture.addCallback(
                 federationCallbackFactory.createDtableSendProducerListenableCallback(results, broker, errorContainer, null, -1));
 
-        ListenableFuture<?> consumerListenableFuture = ioConsumerPool.submitListenable(consumer);
-        consumerListenableFuture.addCallback(
-                federationCallbackFactory.createDefaultConsumerListenableCallback(errorContainer, finishLatch, null, -1));
 
         return finishLatch;
     }

--- a/arch/driver/federation/src/main/java/com/webank/ai/fate/driver/federation/transfer/communication/processor/SendProcessor.java
+++ b/arch/driver/federation/src/main/java/com/webank/ai/fate/driver/federation/transfer/communication/processor/SendProcessor.java
@@ -135,11 +135,9 @@ public class SendProcessor extends BaseTransferProcessor {
             broker.addSubscriber(consumer);
 
             ListenableFuture<?> consumerListenableFuture = ioConsumerPool.submitListenable(consumer);
+            if (consumerListenableFuture != null) {
             consumerListenableFuture.addCallback(
                     federationCallbackFactory.createDefaultConsumerListenableCallback(errorContainer, finishLatch, null, -1));
-
-            if (consumerListenableFuture != null) {
-
                 // todo: add result tracking and retry mechanism
                 ListenableFuture<BasicMeta.ReturnStatus> producerResult = ioProducerPool.submitListenable(producer);
                 producerResult.addCallback(
@@ -167,10 +165,9 @@ public class SendProcessor extends BaseTransferProcessor {
         CountDownLatch finishLatch = new CountDownLatch(1);
 
         ListenableFuture<?> consumerListenableFuture = ioConsumerPool.submitListenable(consumer);
+        if(consumerListenableFuture!=null) {
         consumerListenableFuture.addCallback(
                 federationCallbackFactory.createDefaultConsumerListenableCallback(errorContainer, finishLatch, null, -1));
-        if(consumerListenableFuture!=null) {
-
             ListenableFuture<BasicMeta.ReturnStatus> producerListenableFuture = ioProducerPool.submitListenable(producer);
             producerListenableFuture.addCallback(
                     federationCallbackFactory.createDtableSendProducerListenableCallback(results, broker, errorContainer, null, -1));

--- a/arch/driver/federation/src/main/java/com/webank/ai/fate/driver/federation/transfer/communication/processor/SendProcessor.java
+++ b/arch/driver/federation/src/main/java/com/webank/ai/fate/driver/federation/transfer/communication/processor/SendProcessor.java
@@ -138,12 +138,15 @@ public class SendProcessor extends BaseTransferProcessor {
             consumerListenableFuture.addCallback(
                     federationCallbackFactory.createDefaultConsumerListenableCallback(errorContainer, finishLatch, null, -1));
 
-            // todo: add result tracking and retry mechanism
-            ListenableFuture<BasicMeta.ReturnStatus> producerResult = ioProducerPool.submitListenable(producer);
-            producerResult.addCallback(
-                    federationCallbackFactory.createDtableSendProducerListenableCallback(results, broker, errorContainer, null, -1));
+            if (consumerListenableFuture != null) {
+
+                // todo: add result tracking and retry mechanism
+                ListenableFuture<BasicMeta.ReturnStatus> producerResult = ioProducerPool.submitListenable(producer);
+                producerResult.addCallback(
+                        federationCallbackFactory.createDtableSendProducerListenableCallback(results, broker, errorContainer, null, -1));
 
             }
+        }
 
         return finishLatch;
     }
@@ -166,13 +169,13 @@ public class SendProcessor extends BaseTransferProcessor {
         ListenableFuture<?> consumerListenableFuture = ioConsumerPool.submitListenable(consumer);
         consumerListenableFuture.addCallback(
                 federationCallbackFactory.createDefaultConsumerListenableCallback(errorContainer, finishLatch, null, -1));
+        if(consumerListenableFuture!=null) {
 
+            ListenableFuture<BasicMeta.ReturnStatus> producerListenableFuture = ioProducerPool.submitListenable(producer);
+            producerListenableFuture.addCallback(
+                    federationCallbackFactory.createDtableSendProducerListenableCallback(results, broker, errorContainer, null, -1));
 
-        ListenableFuture<BasicMeta.ReturnStatus> producerListenableFuture = ioProducerPool.submitListenable(producer);
-        producerListenableFuture.addCallback(
-                federationCallbackFactory.createDtableSendProducerListenableCallback(results, broker, errorContainer, null, -1));
-
-
+        }
         return finishLatch;
     }
 


### PR DESCRIPTION
Fixes  ISSUE#207

Changes:

1.  there is a single loop thread in the class arch/driver/federation/src/main/java/com/webank/ai/fate/driver/federation/transfer/communication/TransferJobScheduler.java,   if the pressure is high ,  the single thread can not get thread from threadpool ,so it will throw exception ,then this thread will exit。so there is no thread to handle request 
2.arch/driver/federation/src/main/java/com/webank/ai/fate/driver/federation/transfer/communication/processor/SendProcessor.java
there  are  producer  and  consumer in this class，  but the order of  initialization  is  wrong ，
the  consumer  should  before  producer，because  the consumer sometimes will  initialize failed  under high pressure,  the producor will block  in that case，so  the thread in the threadpool will use up




