### PR TITLE
Improve the fate-flow metric storage

### DIFF
--- a/fate_flow/db/db_models.py
+++ b/fate_flow/db/db_models.py
@@ -145,7 +145,7 @@ class TrackingMetric(DataBaseModel):
         if ModelClass is None:
 
             class Meta:
-                db_table = '%s_%s' % ('tracking_metric', table_index)
+                db_table = '%s_%s' % ('t_tracking_metric', table_index)
 
             attrs = {'__module__': cls.__module__, 'Meta': Meta}
             ModelClass = type("%s_%s" % (cls.__name__, table_index), (cls,),

--- a/fate_flow/settings.py
+++ b/fate_flow/settings.py
@@ -58,7 +58,7 @@ REDIS = {
     'host': '127.0.0.1',
     'port': 6379,
     'password': 'fate_dev',
-    'max_connections': 50
+    'max_connections': 500
 }
 
 server_conf = file_utils.load_json_conf("arch/conf/server_conf.json")


### PR DESCRIPTION
1. delete flow sort tracking metric
2. metric key use pickle to store

Fixes  ISSUE #323 

Changes:

1. Use pickle to serializate metric key
2. Keep the original order when storing metrics, and restore order when reading


