### PR TITLE
fate_flow: download output data using a comma as a separator

### DIFF
--- a/fate_flow/apps/tracking_app.py
+++ b/fate_flow/apps/tracking_app.py
@@ -249,7 +249,7 @@ def component_output_data_download():
     with open(output_data_file_path, 'w') as fw:
         for k, v in output_data_table.collect():
             data_line, have_data_label = get_component_output_data_line(src_key=k, src_value=v)
-            fw.write('{}\n'.format('\t'.join(map(lambda x: str(x), data_line))))
+            fw.write('{}\n'.format(','.join(map(lambda x: str(x), data_line))))
             output_data_count += 1
 
     if output_data_count:


### PR DESCRIPTION
Fixes  ISSUE #451 

Changes:

1. Download output data using a comma as a separator.


